### PR TITLE
fix: reference to broken `client` symlink preventing proper postinstall

### DIFF
--- a/src/server/functions/load-data/package-lock.json
+++ b/src/server/functions/load-data/package-lock.json
@@ -108,7 +108,6 @@
         "lib": {
             "version": "file:../../lib",
             "requires": {
-                "client": "file:../../../client",
                 "fast-glob": "^3.2.4",
                 "node-fetch": "^2.6.0",
                 "nunjucks": "^3.2.1",
@@ -187,9 +186,6 @@
                         "normalize-path": "~3.0.0",
                         "readdirp": "~3.4.0"
                     }
-                },
-                "client": {
-                    "version": "file:../../../client"
                 },
                 "commander": {
                     "version": "3.0.2",

--- a/src/server/functions/render-html/package-lock.json
+++ b/src/server/functions/render-html/package-lock.json
@@ -138,7 +138,6 @@
         "lib": {
             "version": "file:../../lib",
             "requires": {
-                "client": "file:../../../client",
                 "fast-glob": "^3.2.4",
                 "node-fetch": "^2.6.0",
                 "nunjucks": "^3.2.1",
@@ -217,9 +216,6 @@
                         "normalize-path": "~3.0.0",
                         "readdirp": "~3.4.0"
                     }
-                },
-                "client": {
-                    "version": "file:../../../client"
                 },
                 "commander": {
                     "version": "3.0.2",

--- a/src/server/lib/package-lock.json
+++ b/src/server/lib/package-lock.json
@@ -74,9 +74,6 @@
                 "readdirp": "~3.4.0"
             }
         },
-        "client": {
-            "version": "file:../../client"
-        },
         "commander": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",


### PR DESCRIPTION
~~Semi-circular~~ Broken, magic `client` dependency issue was resolved in package files, but not yet in package-locks:

```bash
npm ERR! code ENOENT
npm ERR! syscall access
npm ERR! path /Users/annefortuin/Code/VH/pretty-static/src/server/lib/node_modules/client
npm ERR! errno -2
npm ERR! enoent ENOENT: no such file or directory, access '/Users/annefortuin/Code/VH/pretty-static/src/server/lib/node_modules/client'
npm ERR! enoent This is related to npm not being able to find a file.
```

References are removed, install works fine now (tested on npm `6.14.4`)